### PR TITLE
develop: LockUnset -> Unset

### DIFF
--- a/iterators.go
+++ b/iterators.go
@@ -97,7 +97,7 @@ func (iterationHandler *iterationHandler) Remove(removeIterator iterator) (resul
 			iterationHandler.iterators = nil
 			//iterationHandler.stop()
 			//mapKey := uint64(iterationHandler.iterateInterval.Nanoseconds())
-			//iterationHandlers.m.(interface{ LockUnset(atomicmap.Key) error }).LockUnset(mapKey)
+			//iterationHandlers.m.(interface{ Unset(atomicmap.Key) error }).Unset(mapKey)
 			iterationHandler.Unlock()
 			//iterationHandler.Release()
 			return true

--- a/registry.go
+++ b/registry.go
@@ -210,7 +210,7 @@ func (m *MetricsRegistry) List() (result Metrics) {
 
 func (m *MetricsRegistry) remove(metric Metric) {
 	metric.Stop()
-	m.storage.LockUnset(metric.(interface{ GetKey() []byte }).GetKey())
+	m.storage.Unset(metric.(interface{ GetKey() []byte }).GetKey())
 }
 
 func (m *MetricsRegistry) GetSender() Sender {
@@ -611,7 +611,7 @@ func (m *MetricsRegistry) Reset() {
 			continue
 		}
 		metric.(Metric).Stop()
-		m.storage.LockUnset(metricKey)
+		m.storage.Unset(metricKey)
 	}
 }
 


### PR DESCRIPTION
renamed LockUnset -> Unset because LockUnset is deprecated in latest version of xaionaro-go/atomicmap